### PR TITLE
Fix ID override bug

### DIFF
--- a/src/main/java/com/Bank/App/controller/MensajeControlador.java
+++ b/src/main/java/com/Bank/App/controller/MensajeControlador.java
@@ -53,7 +53,9 @@ public class MensajeControlador {
 		Mensaje mensaje = repositorio.findById(id)
 				.orElseThrow(() -> new ResourceNotFoundException("No existe el mensaje con ID: " + id));
 
-		mensaje.setId(detallesMensaje.getId());
+               // La ID del mensaje debe coincidir con la indicada en la URL
+               // para evitar que se modifique accidentalmente mediante el cuerpo
+               mensaje.setId(id);
 		mensaje.setId_origen(detallesMensaje.getId_origen());
 		mensaje.setId_destino(detallesMensaje.getId_destino());
 		mensaje.setTexto(detallesMensaje.getTexto());

--- a/src/main/java/com/Bank/App/controller/TransferenciaControlador.java
+++ b/src/main/java/com/Bank/App/controller/TransferenciaControlador.java
@@ -52,7 +52,9 @@ public class TransferenciaControlador {
 		Transferencia transferencia = repositorio.findById(id)
 				.orElseThrow(() -> new ResourceNotFoundException("No existe la transferencia con ID: " + id));
 
-		transferencia.setId(detallesTransferencia.getId());
+               // La ID de la transferencia debe mantenerse igual que la indicada en la URL
+               // para evitar inconsistencias si el cuerpo de la petición contiene un valor diferente
+               transferencia.setId(id);
 		transferencia.setId_ordenante(detallesTransferencia.getId_ordenante());
 		transferencia.setId_beneficiario(detallesTransferencia.getId_beneficiario());
 		transferencia.setImporte(detallesTransferencia.getImporte());


### PR DESCRIPTION
## Summary
- ensure update endpoints keep consistent IDs in `TransferenciaControlador` and `MensajeControlador`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687567d80418832b970c027662f51fb5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/azurea08/bank-app-api/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
